### PR TITLE
Fix auto_clip_fac in case of resuming from checkpoint

### DIFF
--- a/tuner_utils/yellowfin.py
+++ b/tuner_utils/yellowfin.py
@@ -359,7 +359,7 @@ class YFOptimizer(object):
     
     if self._clip_thresh != None:
       torch.nn.utils.clip_grad_norm(self._var_list, self._clip_thresh)
-    elif (self._iter != 0 and self._auto_clip_fac != None):
+    elif (hasattr(self, '_h_max') and self._auto_clip_fac != None):
       # do not clip the first iteration
       torch.nn.utils.clip_grad_norm(self._var_list, self.auto_clip_thresh() )
 


### PR DESCRIPTION
When resuming from a checkpoint, `self.iter` is not zero, but `self._h_max` is still undefined, so the optimizer would error.  The PR checks directly if `self._h_max` is defined, which should always work.